### PR TITLE
#47 GetBadgeOperation & RefreshBadgeOperation

### DIFF
--- a/.github/workflows/deploy-prod-aws-functions.yaml
+++ b/.github/workflows/deploy-prod-aws-functions.yaml
@@ -11,8 +11,10 @@ on:
 jobs:
   test-functions:
     uses: "./.github/workflows/integration-tests.yaml"
+
   deploy:
     runs-on: ubuntu-latest
+    environment: Production
     needs: ["test-functions"]
 
     defaults:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,6 +67,14 @@ jobs:
         run: |
           npm install
 
+      # the cache is created without them in the post run.
+      # It also restores the cache if it exists.
+      # In this step, this action saves a list of existing images,
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        name: Supabase images cache
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+
       - name: Install Supabase Environment
         run: |
           cd ~
@@ -74,13 +82,6 @@ jobs:
           cd supabase/docker
           cp .env.example .env
           docker-compose pull
-        # In this step, this action saves a list of existing images,
-        # the cache is created without them in the post run.
-        # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        name: Supabase images cache
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
 
       - name: Start Supabase Environment
         id: supabase

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -68,12 +68,24 @@ jobs:
           npm install
 
       - name: Install Supabase Environment
-        id: supabase
         run: |
           cd ~
           git clone --depth 1 https://github.com/supabase/supabase
           cd supabase/docker
           cp .env.example .env
+          docker-compose pull
+        # In this step, this action saves a list of existing images,
+        # the cache is created without them in the post run.
+        # It also restores the cache if it exists.
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        name: Supabase images cache
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+
+      - name: Start Supabase Environment
+        id: supabase
+        run: |
+          cd ~/supabase/docker
 
           docker compose up -d --wait #start services and wait for containers to be healthy
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,14 +67,6 @@ jobs:
         run: |
           npm install
 
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      # In this step, this action saves a list of existing images,
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        name: Supabase images cache
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       - name: Install Supabase Environment
         run: |
           cd ~

--- a/functions/src/__test__/infrastructure/postgres/ActionRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/ActionRepository.test.ts
@@ -110,4 +110,57 @@ describe.only("ActionsRepositoryTests", () => {
       }
     });
   });
+  describe("GetByCreatorAndName", () => {
+    test("it should return all data", async function () {
+      if (client === null || repo === null) {
+        console.warn("No client connection or repo, skipping test");
+        return;
+      }
+      const res = await repo.getByCreatorAndName("toto", "toto_action");
+      expect(res.name).toEqual("toto_action");
+      expect(res.creator).toEqual("toto");
+    });
+
+    test("its should return an error if there is no action with non existant creator and existant name", async function () {
+      if (client === null || repo === null) {
+        console.warn("No client connection or repo, skipping test");
+        return;
+      }
+      try {
+        await repo.getByCreatorAndName("not_there", "toto_action");
+        fail("Expected error to be thrown");
+      } catch (e) {
+        // pass;
+        return;
+      }
+    });
+
+    test("its should return an error if there is no action with existant creator and non existant name", async function () {
+      if (client === null || repo === null) {
+        console.warn("No client connection or repo, skipping test");
+        return;
+      }
+      try {
+        await repo.getByCreatorAndName("toto", "dontExists");
+        fail("Expected error to be thrown");
+      } catch (e) {
+        // pass;
+        return;
+      }
+    });
+
+    test("its should return an error if there is no action with non existant creator and non existant name", async function () {
+      if (client === null || repo === null) {
+        console.warn("No client connection or repo, skipping test");
+        return;
+      }
+      try {
+        await repo.getByCreatorAndName("not_there", "dontExists");
+        fail("Expected error to be thrown");
+      } catch (e) {
+        // pass;
+        return;
+      }
+    });
+  });
 });

--- a/functions/src/__test__/infrastructure/postgres/ActionRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/ActionRepository.test.ts
@@ -92,6 +92,7 @@ describe.only("ActionsRepositoryTests", () => {
         return;
       }
       const res = await repo.getById(1);
+      expect(res.id).toEqual(1);
       expect(res.name).toEqual("toto_action");
       expect(res.creator).toEqual("toto");
     });

--- a/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
@@ -210,10 +210,11 @@ describe.only("BadgesRepository tests", () => {
         }
 
         try {
-          await repo.getBadge({
+          const a = await repo.getBadge({
             actionId: { name: "tata_action", creator: "tata" },
             metric: "runs",
           });
+          console.log("lookHere", a);
         } catch (e) {
           return;
         }

--- a/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
@@ -150,7 +150,7 @@ describe.only("BadgesRepository tests", () => {
       });
       const a = await repo.getBadge({ actionId: 1, metric: "repos" });
       expect(b.value).not.toEqual(a.value);
-      expect({ ...b, value: "" }).toEqual({ ...b, value: "" });
+      expect({ ...b, value: "" }).toEqual({ ...a, value: "" });
     });
 
     test("it should not error if no updatable parameters are passed", async function () {
@@ -193,6 +193,7 @@ describe.only("BadgesRepository tests", () => {
 
         const badge = await repo.getBadge({ actionId: 1, metric: "runs" });
         expect(badge).toEqual({
+          id: badge.id,
           actionId: 1,
           metric: "runs",
           lastGenerated: new Date(10),
@@ -232,6 +233,7 @@ describe.only("BadgesRepository tests", () => {
           metric: "runs",
         });
         expect(badge).toEqual({
+          id: badge.id,
           actionId: 1,
           metric: "runs",
           lastGenerated: new Date(10),
@@ -263,7 +265,10 @@ describe.only("BadgesRepository tests", () => {
       await repo.createBadge(badge);
 
       const resBadge = await repo.getBadge({ actionId: 2, metric: "repos" });
-      expect(resBadge).toEqual(badge);
+      expect(resBadge).toEqual({
+        ...badge,
+        id: resBadge.id,
+      });
     });
     test("it should error if the action doesn't exist", async function () {
       if (client === null || repo === null) {

--- a/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
@@ -211,7 +211,7 @@ describe.only("BadgesRepository tests", () => {
 
         try {
           await repo.getBadge({
-            actionId: { repo: "tata_action", creator: "tata" },
+            actionId: { name: "tata_action", creator: "tata" },
             metric: "runs",
           });
         } catch (e) {
@@ -227,7 +227,7 @@ describe.only("BadgesRepository tests", () => {
         }
 
         const badge = await repo.getBadge({
-          actionId: { repo: "toto_action", creator: "toto" },
+          actionId: { name: "toto_action", creator: "toto" },
           metric: "runs",
         });
         expect(badge).toEqual({

--- a/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/BadgesRepository.test.ts
@@ -170,34 +170,74 @@ describe.only("BadgesRepository tests", () => {
   });
 
   describe("getBadge", () => {
-    test("it should return an error if there is no badge for the action and metric", async function () {
-      if (client === null || repo === null) {
-        console.warn("No client connection or repo, skipping test");
-        return;
-      }
+    describe("With Number ActionId", () => {
+      test("it should return an error if there is no badge for the action and metric", async function () {
+        if (client === null || repo === null) {
+          console.warn("No client connection or repo, skipping test");
+          return;
+        }
 
-      try {
-        await repo.getBadge({ actionId: 2, metric: "runs" });
-      } catch (e) {
-        return;
-      }
-      fail("Error should have been thrown");
+        try {
+          await repo.getBadge({ actionId: 2, metric: "runs" });
+        } catch (e) {
+          return;
+        }
+        fail("Error should have been thrown");
+      });
+
+      test("it should return the Badge information if it exists", async function () {
+        if (client === null || repo === null) {
+          console.warn("No client connection or repo, skipping test");
+          return;
+        }
+
+        const badge = await repo.getBadge({ actionId: 1, metric: "runs" });
+        expect(badge).toEqual({
+          actionId: 1,
+          metric: "runs",
+          lastGenerated: new Date(10),
+          locationPath: "toto/toto_action/runs",
+          publicUri: "uri://toto/toto_action/runs",
+          value: "100",
+        });
+      });
     });
+    describe("With Repo & Creator ActionId", () => {
+      test("it should return an error if there is no badge for the action and metric", async function () {
+        if (client === null || repo === null) {
+          console.warn("No client connection or repo, skipping test");
+          return;
+        }
 
-    test("it should return the Badge information if it exists", async function () {
-      if (client === null || repo === null) {
-        console.warn("No client connection or repo, skipping test");
-        return;
-      }
+        try {
+          await repo.getBadge({
+            actionId: { repo: "tata_action", creator: "tata" },
+            metric: "runs",
+          });
+        } catch (e) {
+          return;
+        }
+        fail("Error should have been thrown");
+      });
 
-      const badge = await repo.getBadge({ actionId: 1, metric: "runs" });
-      expect(badge).toEqual({
-        actionId: 1,
-        metric: "runs",
-        lastGenerated: new Date(10),
-        locationPath: "toto/toto_action/runs",
-        publicUri: "uri://toto/toto_action/runs",
-        value: "100",
+      test("it should return the Badge information if it exists", async function () {
+        if (client === null || repo === null) {
+          console.warn("No client connection or repo, skipping test");
+          return;
+        }
+
+        const badge = await repo.getBadge({
+          actionId: { repo: "toto_action", creator: "toto" },
+          metric: "runs",
+        });
+        expect(badge).toEqual({
+          actionId: 1,
+          metric: "runs",
+          lastGenerated: new Date(10),
+          locationPath: "toto/toto_action/runs",
+          publicUri: "uri://toto/toto_action/runs",
+          value: "100",
+        });
       });
     });
   });

--- a/functions/src/__test__/infrastructure/postgres/MetricsRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/MetricsRepository.test.ts
@@ -1,0 +1,186 @@
+import * as dotenv from "dotenv";
+import { Client } from "pg";
+import { createClient } from "../../../infrastructure/postgres/PostgresClient";
+import MigrationActionRepository from "../../../infrastructure/postgres/MigrationActionsRepository";
+import MigrationPulseRepoRepository from "../../../infrastructure/postgres/PulseReposRepository";
+import MigrationMetricsRepository from "../../../infrastructure/postgres/MetricsRepository";
+import MigrationActionRunsRepository from "../../../infrastructure/postgres/MigrationActionRunsRepository";
+import ActionRun from "../../../domain/ActionRun.type";
+
+describe.only("BadgesRepository tests", () => {
+  let client: null | Client = null;
+  let repo: null | MigrationMetricsRepository = null;
+
+  // Setup
+  beforeAll(async () => {
+    dotenv.config();
+    try {
+      client = createClient();
+      await client.connect();
+    } catch (e) {
+      console.warn("Unable to connect to client, skipping tests.");
+      client = null;
+      return;
+    }
+    let actionRunRepo;
+    try {
+      await MigrationActionRepository.New(client); // create the action repository
+      await MigrationPulseRepoRepository.New(client); // create the pulse repo
+
+      actionRunRepo = await MigrationActionRunsRepository.New(client); // create the Action repository if it doesn't already exist
+      repo = await MigrationMetricsRepository.New(client);
+    } catch (e) {
+      console.warn(`Error creating Badges or Action run repo: ${e}`);
+      repo = null;
+      return;
+    }
+    // populate db
+    try {
+      await client.query(`
+                         DELETE FROM "Runs";
+                         DELETE FROM "Actions";
+                         DELETE FROM "PulseRepos";
+                         DELETE FROM "MetricDefinitions";
+                        `); // Drop all values from tables
+
+      // create placeholder toto action
+      await client.query(
+        'INSERT INTO "Actions" (id, creator, name, last_update) VALUES (1, $1, $2, $3);',
+        ["toto", "toto_action", new Date(100)]
+      );
+
+      // create placeholder pusle repo
+      await client.query(
+        'INSERT INTO "PulseRepos" (id, owner, name, hashed_name, full_name, full_hashed_name) VALUES (1,$1,$2,$3,$4,$5 )',
+        ["user", "repository", "1234", "user/repository", "user/1234"]
+      );
+      const ar: ActionRun = {
+        creator: "toto",
+        github_action: "workflow_step_name",
+        github_actor: "actor",
+        github_base_ref: "base/ref",
+        github_head_ref: "head/ref",
+        github_ref: "base/ref",
+        github_repository: "user/repository",
+        github_run_id: "1234353",
+        github_event_name: "push",
+        github_action_repository: "michmich112/versionbumper@main",
+        package_version: "0.1.0",
+        ip: "1.2.3.4",
+        name: "toto_action",
+        runner_os: "Linux",
+        runner_name: "HostedRunner",
+        timestamp: new Date().toISOString(),
+        version: "main_branch",
+        execution_time: [0, 123456789],
+        error: null,
+      };
+
+      // Create two runs
+      await actionRunRepo.create({
+        actionId: 1,
+        pulseRepoId: 1,
+        run: ar,
+      });
+
+      await actionRunRepo.create({
+        actionId: 1,
+        pulseRepoId: 1,
+        run: {
+          ...ar,
+          github_run_id: "11111111",
+          timestamp: new Date(1111111).toISOString(),
+        },
+      });
+
+      // create metric 'runs'
+      await client.query(
+        `INSERT INTO "MetricDefinitions" (metric, query, parameters, return_column)
+        VALUES ($1, $2, $3, $4);`,
+        [
+          "runs",
+          'SELECT count(*) as runs FROM "Runs" WHERE action_id = $1;',
+          ["actionId"],
+          "runs",
+        ]
+      );
+    } catch (e) {
+      console.warn(
+        `Error populating known values: Some tests might fail; ${e}`
+      );
+    }
+  });
+
+  // Teardown
+  afterAll(async () => {
+    if (client !== null) {
+      try {
+        await client.query(`                         
+                         DELETE FROM "Runs";
+                         DELETE FROM "Actions";
+                         DELETE FROM "PulseRepos";
+                         DELETE FROM "MetricDefinitions"
+                         `); // Drop all values from Badges & Actions
+      } catch (e) {
+        console.error(`ERROR Tearing Down: ${e}.`);
+      }
+      await client.end();
+    }
+    return;
+  });
+
+  describe("metricExists", () => {
+    test("it should return true if the metric exists", async function () {
+      if (client === null || repo === null) {
+        throw new Error("No client connection or repo, skipping test");
+      }
+
+      const res = await repo.metricExists("runs");
+      expect(res).toBeTruthy();
+    });
+    test("it should return false if the metric doesn't exist", async function () {
+      if (client === null || repo === null) {
+        throw new Error("No client connection or repo, skipping test");
+      }
+
+      const res = await repo.metricExists("non-existing-metric");
+      expect(res).toBeFalsy();
+    });
+  });
+
+  describe("computeMetric", () => {
+    test("it should return the computed value for an existing metric with existing params", async function () {
+      if (client === null || repo === null) {
+        throw new Error("No client connection or repo, skipping test");
+      }
+
+      const res = await repo.computeMetric("runs", { actionId: 1 });
+      expect(res).toEqual("2");
+    });
+
+    test("it should throw an error if not all parameters are passed for the metric", async function () {
+      if (client === null || repo === null) {
+        throw new Error("No client connection or repo, skipping test");
+      }
+
+      try {
+        await repo.computeMetric("runs", {});
+      } catch {
+        return;
+      }
+      throw new Error("Expected Error to be thrown");
+    });
+    test("it should throw an error if choosing a non-existant metric", async function () {
+      if (client === null || repo === null) {
+        throw new Error("No client connection or repo, skipping test");
+      }
+
+      try {
+        await repo.computeMetric("non-existing", { actionId: 1 });
+      } catch {
+        return;
+      }
+      throw new Error("Expected Error to be thrown");
+    });
+  });
+});

--- a/functions/src/__test__/infrastructure/postgres/MetricsRepository.test.ts
+++ b/functions/src/__test__/infrastructure/postgres/MetricsRepository.test.ts
@@ -7,7 +7,7 @@ import MigrationMetricsRepository from "../../../infrastructure/postgres/Metrics
 import MigrationActionRunsRepository from "../../../infrastructure/postgres/MigrationActionRunsRepository";
 import ActionRun from "../../../domain/ActionRun.type";
 
-describe.only("BadgesRepository tests", () => {
+describe.only("MetricsRepository tests", () => {
   let client: null | Client = null;
   let repo: null | MigrationMetricsRepository = null;
 

--- a/functions/src/__test__/operations/CollectActionRun.test.ts
+++ b/functions/src/__test__/operations/CollectActionRun.test.ts
@@ -44,13 +44,16 @@ LEFT JOIN (
 `;
 
 async function wipeData(client: Client) {
-  await client.query(`
-                       DELETE FROM "Runs";
-                       DELETE FROM "Actions";
-                       DELETE FROM "RunErrors";
-                       DELETE FROM "AttemptedRuns";
-                       DELETE FROM "PulseRepos";
-                       `);
+  const allWiped = await Promise.allSettled([
+    client.query('DELETE FROM "Runs";'),
+    client.query('DELETE FROM "Actions";'),
+    client.query('DELETE FROM "RunErrors";'),
+    client.query('DELETE FROM "AttemptedRuns";'),
+    client.query('DELETE FROM "PulseRepos";'),
+  ]);
+
+  if (allWiped.filter((q) => q.status === "rejected").length > 0)
+    throw new Error("Unable to clear some relations");
 }
 
 const MockComsErrorMessage = "Communication Error";

--- a/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
@@ -1,0 +1,203 @@
+import { makeBadge } from "badge-maker";
+import * as dotenv from "dotenv";
+import { Client } from "pg";
+import ActionRun from "../../domain/ActionRun.type";
+import Badge from "../../domain/Badge.type";
+import BadgeMetrics from "../../domain/BadgeMetrics.type";
+import MigrationBadgesRepository from "../../infrastructure/postgres/BadgesRepository";
+import MigrationActionRepository from "../../infrastructure/postgres/MigrationActionsRepository";
+import { PostgresConnectedClient } from "../../infrastructure/postgres/PostgresClient";
+import { CollectActionRun } from "../../operations/CollectActionRun";
+import { GetBadgeOperation } from "../../operations/MigrationGetBadgeOperation";
+
+const utils = require("../../utils/githubUtils");
+
+async function wipeData(client: Client) {
+  await client.query(`
+                       DELETE FROM "Runs";
+                       DELETE FROM "Actions";
+                       DELETE FROM "RunErrors";
+                       DELETE FROM "AttemptedRuns";
+                       DELETE FROM "PulseRepos";
+                       DELETE FROM "MetricDefinitions";
+                       `);
+}
+
+async function setup(client: Client) {
+  const run: ActionRun = {
+    creator: "michmich112",
+    github_action: "action",
+    github_actor: "actor",
+    github_base_ref: "base",
+    github_head_ref: "head",
+    github_ref: "ref",
+    github_repository: "repository",
+    github_event_name: "push",
+    github_action_repository: "action_repository",
+    github_run_id: "1",
+    ip: "1.2.3.4",
+    name: "action-name",
+    runner_os: "Linux",
+    runner_name: "Runner1",
+    timestamp: new Date(12345).toISOString(),
+    version: "version_number",
+    package_version: "1.2.3",
+    execution_time: [1, 123456789],
+    error: {
+      name: "Error",
+      message: "Error encountered",
+      stack: null,
+    },
+  };
+
+  // create 2 normal runs and 1 attempted run
+  await CollectActionRun(run); // use the operation to create the mock data
+
+  await CollectActionRun({
+    ...run,
+    timestamp: new Date(123456).toISOString(),
+    error: null,
+  });
+  // this is a attempted Run
+  await CollectActionRun({
+    ...run,
+    timestamp: new Date().toISOString(),
+    error: null,
+    ip: "1.4.7.78",
+  });
+
+  client = (await PostgresConnectedClient()) as Client;
+
+  const actionRepo = await MigrationActionRepository.New(client);
+  const action = await actionRepo.getByCreatorAndName(
+    "michmich112",
+    "action-name"
+  );
+
+  const badgeRepo = await MigrationBadgesRepository.New(client);
+  const badge: Badge = {
+    actionId: action.id,
+    metric: "test_upToDate" as BadgeMetrics,
+    lastGenerated: new Date(),
+    locationPath: "/test/up_to_date",
+    publicUri: "public/url/file.svg",
+    value: "10",
+  };
+
+  await badgeRepo.createBadge(badge);
+  const badge2: Badge = {
+    actionId: action.id,
+    metric: "test_notUpToDate" as BadgeMetrics,
+    lastGenerated: new Date(0),
+    locationPath: "/test/not_up_to_date",
+    publicUri: "public/url/file_not_up_to_dat.svg",
+    value: "12",
+  };
+  await badgeRepo.createBadge(badge2);
+}
+
+describe("GetBadgeOperation test", () => {
+  let client: Client | null = null;
+  beforeAll(async function () {
+    dotenv.config();
+    client = await PostgresConnectedClient();
+
+    await wipeData(client!);
+
+    jest
+      .spyOn(utils, "isGithubActionsAddress")
+      .mockImplementation(async (ip) => {
+        if (ip === "9.9.9.9") {
+          // mock a communication error
+          throw new Error("Communication Error");
+        }
+
+        const authorizedIps = ["1.2.3.4", "5.6.7.8", "1:2:3:4:5:6:7:8"];
+        return authorizedIps.includes(ip as string);
+      });
+
+    await setup(client!);
+  });
+
+  afterAll(async function () {
+    await wipeData(client!);
+    await client!.end();
+  });
+
+  test("it should return the URL if the badge exists and is up to date", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const res = await GetBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "test_upToDate" as BadgeMetrics,
+    });
+    client = (await PostgresConnectedClient()) as Client;
+
+    expect(res).toEqual({
+      url: "public/url/file.svg",
+      outdated: false,
+    });
+  });
+
+  test("it should return the URL and outdated if the badge is not up do date", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const res = await GetBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "test_notUpToDate" as BadgeMetrics,
+    });
+    client = (await PostgresConnectedClient()) as Client;
+
+    expect(res).toEqual({
+      url: "public/url/file_not_up_to_dat.svg",
+      outdated: true,
+    });
+  });
+
+  test("it should return the raw metric if no badge exists", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const res = await GetBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "runs" as BadgeMetrics,
+    });
+    client = (await PostgresConnectedClient()) as Client;
+
+    expect(res).toEqual({
+      raw: makeBadge({ label: "Runs", color: "green", message: "2" }),
+      outdated: true,
+    });
+  });
+
+  test("it should return an error if the metric is not defined", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const res = await GetBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "doesNotExist" as BadgeMetrics,
+    });
+
+    client = (await PostgresConnectedClient()) as Client;
+
+    expect(res).toHaveProperty("err");
+    expect(res).not.toHaveProperty("raw");
+    expect(res).not.toHaveProperty("url");
+    expect(res).not.toHaveProperty("outdated");
+  });
+});

--- a/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
@@ -140,6 +140,10 @@ describe("GetBadgeOperation test", () => {
     }
   });
 
+  beforeEach(async function () {
+    client = await PostgresConnectedClient();
+  });
+
   test("it should return the URL if the badge exists and is up to date", async function () {
     if (!client) {
       console.warn("No client connection, failing test.");

--- a/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationGetBadgeOperation.test.ts
@@ -17,6 +17,7 @@ async function wipeData(client: Client) {
     await client.query('DELETE FROM "Runs";');
   } catch (e) {
     console.warn("Error Deleting Runs", e);
+    client = (await PostgresConnectedClient()) as Client;
   }
   await Promise.allSettled([
     client.query('DELETE FROM "Actions";'),

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -118,27 +118,32 @@ describe("RefreshBadgeOperation tests", () => {
       console.warn("Error Wiping Data", e);
     }
 
-    const supabaseClient = getClient();
-    // empty all existing badges
-    await supabaseClient.storage.emptyBucket("badges");
+    try {
+      const supabaseClient = getClient();
+      // empty all existing badges
+      await supabaseClient.storage.emptyBucket("badges");
 
-    jest
-      .spyOn(utils, "isGithubActionsAddress")
-      .mockImplementation(async (ip) => {
-        if (ip === "9.9.9.9") {
-          // mock a communication error
-          throw new Error("Communication Error");
-        }
+      jest
+        .spyOn(utils, "isGithubActionsAddress")
+        .mockImplementation(async (ip) => {
+          if (ip === "9.9.9.9") {
+            // mock a communication error
+            throw new Error("Communication Error");
+          }
 
-        const authorizedIps = ["1.2.3.4", "5.6.7.8", "1:2:3:4:5:6:7:8"];
-        return authorizedIps.includes(ip as string);
-      });
+          const authorizedIps = ["1.2.3.4", "5.6.7.8", "1:2:3:4:5:6:7:8"];
+          return authorizedIps.includes(ip as string);
+        });
 
-    await setup(client!);
+      await setup(client!);
+    } catch (e) {
+      console.error("Setup Failure:", e);
+    }
   });
 
   afterAll(async function () {
     try {
+      client = await PostgresConnectedClient();
       await wipeData(client!);
     } finally {
       await client!.end();

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -1,0 +1,254 @@
+import axios from "axios";
+import * as dotenv from "dotenv";
+import { Client } from "pg";
+import ActionRun from "../../domain/ActionRun.type";
+import Badge from "../../domain/Badge.type";
+import BadgeMetrics from "../../domain/BadgeMetrics.type";
+import MigrationBadgesRepository from "../../infrastructure/postgres/BadgesRepository";
+import MigrationActionRepository from "../../infrastructure/postgres/MigrationActionsRepository";
+import { PostgresConnectedClient } from "../../infrastructure/postgres/PostgresClient";
+import { getClient } from "../../infrastructure/supabase/SupabaseClient";
+import { CollectActionRun } from "../../operations/CollectActionRun";
+import { RefreshBadgeOperation } from "../../operations/MigrationRefreshBadgeOperation";
+
+const utils = require("../../utils/githubUtils");
+
+async function wipeData(client: Client) {
+  await client.query(`
+                       DELETE FROM "Runs";
+                       DELETE FROM "Actions";
+                       DELETE FROM "RunErrors";
+                       DELETE FROM "AttemptedRuns";
+                       DELETE FROM "PulseRepos";
+                       DELETE FROM "MetricDefinitions";
+                       `);
+}
+
+async function setup(client: Client) {
+  const run: ActionRun = {
+    creator: "michmich112",
+    github_action: "action",
+    github_actor: "actor",
+    github_base_ref: "base",
+    github_head_ref: "head",
+    github_ref: "ref",
+    github_repository: "repository",
+    github_event_name: "push",
+    github_action_repository: "action_repository",
+    github_run_id: "1",
+    ip: "1.2.3.4",
+    name: "action-name",
+    runner_os: "Linux",
+    runner_name: "Runner1",
+    timestamp: new Date(12345).toISOString(),
+    version: "version_number",
+    package_version: "1.2.3",
+    execution_time: [1, 123456789],
+    error: {
+      name: "Error",
+      message: "Error encountered",
+      stack: null,
+    },
+  };
+
+  // create 2 normal runs and 1 attempted run
+  await CollectActionRun(run); // use the operation to create the mock data
+
+  await CollectActionRun({
+    ...run,
+    timestamp: new Date(123456).toISOString(),
+    error: null,
+  });
+  // this is a attempted Run
+  await CollectActionRun({
+    ...run,
+    timestamp: new Date().toISOString(),
+    error: null,
+    ip: "1.4.7.78",
+  });
+
+  // create new action
+  await CollectActionRun({
+    ...run,
+    creator: "michmich112",
+    name: "new-action",
+  });
+
+  client = (await PostgresConnectedClient()) as Client;
+
+  const actionRepo = await MigrationActionRepository.New(client);
+  const action = await actionRepo.getByCreatorAndName(
+    "michmich112",
+    "action-name"
+  );
+
+  const badgeRepo = await MigrationBadgesRepository.New(client);
+  const badge: Badge = {
+    actionId: action.id,
+    metric: "rpm" as BadgeMetrics,
+    lastGenerated: new Date(),
+    locationPath: "test/up_to_date.svg",
+    publicUri: "public/url/file.svg",
+    value: "10",
+  };
+
+  await badgeRepo.createBadge(badge);
+  const badge2: Badge = {
+    actionId: action.id,
+    metric: "runs" as BadgeMetrics,
+    lastGenerated: new Date(0),
+    locationPath: "test/not_up_to_date.svg",
+    publicUri: "public/url/file_not_up_to_dat.svg",
+    value: "12",
+  };
+  await badgeRepo.createBadge(badge2);
+}
+
+describe("RefreshBadgeOperation tests", () => {
+  let client: Client | null = null;
+  beforeAll(async function () {
+    dotenv.config();
+    client = await PostgresConnectedClient();
+    await wipeData(client!);
+
+    const supabaseClient = getClient();
+    // empty all existing badges
+    await supabaseClient.storage.emptyBucket("badges");
+
+    jest
+      .spyOn(utils, "isGithubActionsAddress")
+      .mockImplementation(async (ip) => {
+        if (ip === "9.9.9.9") {
+          // mock a communication error
+          throw new Error("Communication Error");
+        }
+
+        const authorizedIps = ["1.2.3.4", "5.6.7.8", "1:2:3:4:5:6:7:8"];
+        return authorizedIps.includes(ip as string);
+      });
+
+    await setup(client!);
+  });
+
+  afterAll(async function () {
+    await wipeData(client!);
+    await client!.end();
+  });
+
+  test("it not perfom any update if the badge is already up to date", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const badgeRepo = await MigrationBadgesRepository.New(client);
+    const startBadge = await badgeRepo.getBadge({
+      actionId: { creator: "michmich112", name: "action-name" },
+      metric: "rpm" as BadgeMetrics,
+    });
+
+    await RefreshBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "rpm",
+    });
+
+    client = (await PostgresConnectedClient()) as Client;
+
+    const endBadge = await badgeRepo.getBadge({
+      actionId: { creator: "michmich112", name: "action-name" },
+      metric: "rpm" as BadgeMetrics,
+    });
+    expect(endBadge).toEqual(startBadge);
+  });
+
+  test("it should perform an update on an existing not up to date badge", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const badgeRepo = await MigrationBadgesRepository.New(client);
+    const startBadge = await badgeRepo.getBadge({
+      actionId: { creator: "michmich112", name: "action-name" },
+      metric: "runs" as BadgeMetrics,
+    });
+
+    await RefreshBadgeOperation({
+      creator: "michmich112",
+      name: "action-name",
+      metric: "runs",
+    });
+
+    client = (await PostgresConnectedClient()) as Client;
+
+    const endBadge = await badgeRepo.getBadge({
+      actionId: { creator: "michmich112", name: "rpm" },
+      metric: "runs" as BadgeMetrics,
+    });
+
+    expect(endBadge).not.toEqual(startBadge);
+    expect(endBadge.locationPath).toEqual("test/not_up_to_date.svg");
+    expect(endBadge.publicUri).not.toEqual("public/url/file_not_up_to_dat.svg");
+    expect(endBadge.value).toEqual("2");
+    expect(endBadge.lastGenerated).not.toEqual(new Date(0));
+
+    // test that the uri generated properly links to the badge
+    const supabaseClient = getClient();
+    const test_uri = await axios.get(endBadge.publicUri);
+
+    const { data, error } = await supabaseClient.storage
+      .from("badges")
+      .download(endBadge.locationPath);
+    if (error) throw new Error("Unable to download badge from storage");
+    expect(await data.text()).toEqual(test_uri.data);
+  });
+
+  test("it should create a badge if it does not exist currently", async function () {
+    if (!client) {
+      console.warn("No client connection, failing test.");
+      throw new Error("No Client Connection");
+    }
+
+    const badgeRepo = await MigrationBadgesRepository.New(client);
+    let err = false;
+    try {
+      await badgeRepo.getBadge({
+        actionId: { creator: "michmich112", name: "new-action" },
+        metric: "runs" as BadgeMetrics,
+      });
+    } catch {
+      err = true;
+    }
+    if (!err)
+      throw new Error(
+        "Expected no badge to exist for action michmich112/new-action"
+      );
+
+    await RefreshBadgeOperation({
+      creator: "michmich112",
+      name: "new-action",
+      metric: "runs",
+    });
+
+    client = (await PostgresConnectedClient()) as Client;
+
+    const endBadge = await badgeRepo.getBadge({
+      actionId: { creator: "michmich112", name: "rpm" },
+      metric: "runs" as BadgeMetrics,
+    });
+
+    expect(endBadge.locationPath).toEqual("michmich112/new-action/runs.svg");
+    expect(endBadge.value).toEqual("1");
+
+    // test that the uri generated properly links to the badge
+    const supabaseClient = getClient();
+    const test_uri = await axios.get(endBadge.publicUri);
+
+    const { data, error } = await supabaseClient.storage
+      .from("badges")
+      .download(endBadge.locationPath);
+    if (error) throw new Error("Unable to download badge from storage");
+    expect(await data.text()).toEqual(test_uri.data);
+  });
+});

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -15,6 +15,7 @@ const utils = require("../../utils/githubUtils");
 
 async function wipeData(client: Client) {
   const allWiped = await Promise.allSettled([
+    client.query('DELETE FROM "Badges";'),
     client.query('DELETE FROM "Runs";'),
     client.query('DELETE FROM "Actions";'),
     client.query('DELETE FROM "RunErrors";'),
@@ -105,7 +106,8 @@ async function setup(client: Client) {
     value: "12",
   };
   await badgeRepo.createBadge(badge2);
-  console.log("SETUP SUCCESS");
+  const bbb = await client.query('SELECT * FROM "Badges";');
+  console.log("SETUP SUCCESS:", JSON.stringify(bbb));
 }
 
 describe("RefreshBadgeOperation tests", () => {

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -105,6 +105,7 @@ async function setup(client: Client) {
     value: "12",
   };
   await badgeRepo.createBadge(badge2);
+  console.log("SETUP SUCCESS");
 }
 
 describe("RefreshBadgeOperation tests", () => {

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -138,8 +138,11 @@ describe("RefreshBadgeOperation tests", () => {
   });
 
   afterAll(async function () {
-    await wipeData(client!);
-    await client!.end();
+    try {
+      await wipeData(client!);
+    } finally {
+      await client!.end();
+    }
   });
 
   test("it not perfom any update if the badge is already up to date", async function () {
@@ -148,7 +151,7 @@ describe("RefreshBadgeOperation tests", () => {
       throw new Error("No Client Connection");
     }
 
-    const badgeRepo = await MigrationBadgesRepository.New(client);
+    let badgeRepo = await MigrationBadgesRepository.New(client);
     const startBadge = await badgeRepo.getBadge({
       actionId: { creator: "michmich112", name: "action-name" },
       metric: "rpm" as BadgeMetrics,
@@ -162,6 +165,7 @@ describe("RefreshBadgeOperation tests", () => {
 
     client = (await PostgresConnectedClient()) as Client;
 
+    badgeRepo = await MigrationBadgesRepository.New(client);
     const endBadge = await badgeRepo.getBadge({
       actionId: { creator: "michmich112", name: "action-name" },
       metric: "rpm" as BadgeMetrics,
@@ -175,7 +179,7 @@ describe("RefreshBadgeOperation tests", () => {
       throw new Error("No Client Connection");
     }
 
-    const badgeRepo = await MigrationBadgesRepository.New(client);
+    let badgeRepo = await MigrationBadgesRepository.New(client);
     const startBadge = await badgeRepo.getBadge({
       actionId: { creator: "michmich112", name: "action-name" },
       metric: "runs" as BadgeMetrics,
@@ -189,6 +193,7 @@ describe("RefreshBadgeOperation tests", () => {
 
     client = (await PostgresConnectedClient()) as Client;
 
+    badgeRepo = await MigrationBadgesRepository.New(client);
     const endBadge = await badgeRepo.getBadge({
       actionId: { creator: "michmich112", name: "rpm" },
       metric: "runs" as BadgeMetrics,
@@ -217,7 +222,7 @@ describe("RefreshBadgeOperation tests", () => {
       throw new Error("No Client Connection");
     }
 
-    const badgeRepo = await MigrationBadgesRepository.New(client);
+    let badgeRepo = await MigrationBadgesRepository.New(client);
     let err = false;
     try {
       await badgeRepo.getBadge({
@@ -240,6 +245,7 @@ describe("RefreshBadgeOperation tests", () => {
 
     client = (await PostgresConnectedClient()) as Client;
 
+    badgeRepo = await MigrationBadgesRepository.New(client);
     const endBadge = await badgeRepo.getBadge({
       actionId: { creator: "michmich112", name: "rpm" },
       metric: "runs" as BadgeMetrics,

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -95,8 +95,8 @@ async function setup(client: Client) {
     publicUri: "public/url/file.svg",
     value: "10",
   };
-
   await badgeRepo.createBadge(badge);
+
   const badge2: Badge = {
     actionId: action.id,
     metric: "runs" as BadgeMetrics,

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import * as dotenv from "dotenv";
 import { Client } from "pg";
 import ActionRun from "../../domain/ActionRun.type";
-import Badge from "../../domain/Badge.type";
+import { BadgeData } from "../../domain/Badge.type";
 import BadgeMetrics from "../../domain/BadgeMetrics.type";
 import MigrationBadgesRepository from "../../infrastructure/postgres/BadgesRepository";
 import MigrationActionRepository from "../../infrastructure/postgres/MigrationActionsRepository";
@@ -87,7 +87,7 @@ async function setup(client: Client) {
   );
 
   const badgeRepo = await MigrationBadgesRepository.New(client);
-  const badge: Badge = {
+  const badge: BadgeData = {
     actionId: action.id,
     metric: "rpm" as BadgeMetrics,
     lastGenerated: new Date(),
@@ -97,7 +97,7 @@ async function setup(client: Client) {
   };
   await badgeRepo.createBadge(badge);
 
-  const badge2: Badge = {
+  const badge2: BadgeData = {
     actionId: action.id,
     metric: "runs" as BadgeMetrics,
     lastGenerated: new Date(0),

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -141,6 +141,10 @@ describe("RefreshBadgeOperation tests", () => {
     }
   });
 
+  beforeEach(async function () {
+    client = await PostgresConnectedClient();
+  });
+
   afterAll(async function () {
     try {
       client = await PostgresConnectedClient();

--- a/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
+++ b/functions/src/__test__/operations/MigrationRefreshBadgeOperation.test.ts
@@ -207,7 +207,7 @@ describe("RefreshBadgeOperation tests", () => {
 
     badgeRepo = await MigrationBadgesRepository.New(client);
     const endBadge = await badgeRepo.getBadge({
-      actionId: { creator: "michmich112", name: "rpm" },
+      actionId: { creator: "michmich112", name: "action-name" },
       metric: "runs" as BadgeMetrics,
     });
 
@@ -259,7 +259,7 @@ describe("RefreshBadgeOperation tests", () => {
 
     badgeRepo = await MigrationBadgesRepository.New(client);
     const endBadge = await badgeRepo.getBadge({
-      actionId: { creator: "michmich112", name: "rpm" },
+      actionId: { creator: "michmich112", name: "new-action" },
       metric: "runs" as BadgeMetrics,
     });
 

--- a/functions/src/domain/Badge.type.ts
+++ b/functions/src/domain/Badge.type.ts
@@ -1,12 +1,16 @@
 import BadgeMetrics from "./BadgeMetrics.type";
 
-type Badge = {
+interface Badge extends BadgeData {
+  id: number;
+}
+
+export interface BadgeData {
   actionId: number;
   metric: BadgeMetrics;
   lastGenerated: Date;
   locationPath: string;
   publicUri: string;
   value: string;
-};
+}
 
 export default Badge;

--- a/functions/src/domain/methods/badges/generateBadge.ts
+++ b/functions/src/domain/methods/badges/generateBadge.ts
@@ -1,0 +1,15 @@
+import { makeBadge } from "badge-maker";
+
+type badgeDefinition = {
+  label: string;
+  color?: string;
+  value: string;
+};
+
+export default function generateBadge(config: badgeDefinition): string {
+  return makeBadge({
+    label: config.label,
+    color: config.color ?? "green",
+    message: config.value,
+  });
+}

--- a/functions/src/domain/methods/badges/getBadgeLabel.ts
+++ b/functions/src/domain/methods/badges/getBadgeLabel.ts
@@ -1,0 +1,12 @@
+export default function getBadgeLabel(metric: string): string {
+  switch (metric) {
+    case "runs":
+      return "Runs";
+    case "runs-per-month":
+      return "Runs Per Month";
+    case "repos":
+      return "Repositories";
+    default:
+      return "Metric";
+  }
+}

--- a/functions/src/domain/methods/badges/getBadgeStoragePath.ts
+++ b/functions/src/domain/methods/badges/getBadgeStoragePath.ts
@@ -1,0 +1,13 @@
+export default function getBadgeStoragePath({
+  creator,
+  name,
+  metric,
+  fileExt = "svg",
+}: {
+  creator: string;
+  name: string;
+  metric: string;
+  fileExt?: string;
+}): string {
+  return `${creator}/${name}/${metric}.${fileExt}`;
+}

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -133,7 +133,7 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
       LEFT JOIN (
         SELECT 
           aa.repo,
-          aa.creator,
+          aa.creator
         FROM "Actions" aa
       ) a ON a.repo = $1 AND a.creator = $2 
       WHERE b.metric = $3;

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -132,11 +132,12 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
       from "${this.tableName}" b 
       LEFT JOIN (
         SELECT 
+          aa.id,
           aa.name,
           aa.creator
         FROM "Actions" aa
-      ) a ON a.name = $1 AND a.creator = $2 
-      WHERE b.metric = $3;
+      ) a ON a.id = b.action_id
+      WHERE a.name = $1 AND a.creator = $2 AND b.metric = $3;
       `;
       res = await this.client.query(query, [
         actionId.name,

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -147,9 +147,9 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
     }
 
     if (res.rowCount < 1) {
-      const message = `[BadgesRepository][getBadge] Error - No record found for badge for action_id: ${actionId} and metric: ${JSON.stringify(
-        metric
-      )}`;
+      const message = `[BadgesRepository][getBadge] Error - No record found for badge for action_id: ${JSON.stringify(
+        actionId
+      )} and metric: ${JSON.stringify(metric)}`;
       console.error(message);
       throw new Error(message);
     }

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -116,7 +116,7 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
     actionId,
     metric,
   }: {
-    actionId: number | { repo: string; creator: string };
+    actionId: number | { name: string; creator: string };
     metric: BadgeMetrics;
   }): Promise<Badge> {
     let res;
@@ -132,14 +132,14 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
       from "${this.tableName}" b 
       LEFT JOIN (
         SELECT 
-          aa.repo,
+          aa.name,
           aa.creator
         FROM "Actions" aa
-      ) a ON a.repo = $1 AND a.creator = $2 
+      ) a ON a.name = $1 AND a.creator = $2 
       WHERE b.metric = $3;
       `;
       res = await this.client.query(query, [
-        actionId.repo,
+        actionId.name,
         actionId.creator,
         metric,
       ]);

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -1,5 +1,5 @@
 import { Client } from "pg";
-import Badge from "../../domain/Badge.type";
+import Badge, { BadgeData } from "../../domain/Badge.type";
 import BadgeMetrics from "../../domain/BadgeMetrics.type";
 
 import { IPostgresRepostiory } from "../../domain/IRepository";
@@ -157,7 +157,7 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
     return BadgeMapper(res.rows[0]);
   }
 
-  public async createBadge(badge: Badge): Promise<void> {
+  public async createBadge(badge: BadgeData): Promise<void> {
     const query = `
       INSERT INTO "${this.tableName}" (
         action_id, 
@@ -206,17 +206,6 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
   }
 }
 
-// function dbBadgeMapper(b: object): Badge {
-//   return Object.keys(b).reduce(
-//     (acc, cur) => ({
-//       ...acc,
-//       [cur.replace(/_[a-z]/g, (l) => l.toUpperCase()).replace(/_/g, "")]:
-//         b[cur as keyof typeof b], // change to CamelCase
-//     }),
-//     {}
-//   ) as Badge;
-// }
-
 type DbBadge = {
   id: string;
   action_id: string;
@@ -227,7 +216,7 @@ type DbBadge = {
   value: string;
 };
 
-function BadgeMapper(b: DbBadge): Badge {
+function BadgeDataMapper(b: DbBadge): BadgeData {
   return {
     actionId: parseInt(b.action_id, 10),
     metric: b.metric as BadgeMetrics,
@@ -235,5 +224,12 @@ function BadgeMapper(b: DbBadge): Badge {
     locationPath: b.location_path,
     publicUri: b.public_uri,
     value: b.value,
+  };
+}
+
+function BadgeMapper(b: DbBadge): Badge {
+  return {
+    id: parseInt(b.id),
+    ...BadgeDataMapper(b),
   };
 }

--- a/functions/src/infrastructure/postgres/BadgesRepository.ts
+++ b/functions/src/infrastructure/postgres/BadgesRepository.ts
@@ -147,7 +147,9 @@ export default class MigrationBadgesRepository implements IPostgresRepostiory {
     }
 
     if (res.rowCount < 1) {
-      const message = `[BadgesRepository][getBadge] Error - No record found for badge for action_id: ${actionId} and metric: ${metric}`;
+      const message = `[BadgesRepository][getBadge] Error - No record found for badge for action_id: ${actionId} and metric: ${JSON.stringify(
+        metric
+      )}`;
       console.error(message);
       throw new Error(message);
     }

--- a/functions/src/infrastructure/postgres/MetricsRepository.ts
+++ b/functions/src/infrastructure/postgres/MetricsRepository.ts
@@ -1,0 +1,87 @@
+import { Client } from "pg";
+import { IPostgresRepostiory } from "../../domain/IRepository";
+
+const tableSchema: string = `
+CREATE TABLE IF NOT EXISTS "MetricDefinitions" (
+  "metric" TEXT PRIMARY KEY,
+  "query" TEXT NOT NULL,
+  "parameters" TEXT[] NOT NULL,
+  "return_column" TEXT
+);
+`;
+
+export default class MigrationMetricsRepository implements IPostgresRepostiory {
+  tableName: string;
+  client: Client;
+
+  private constructor(client: Client) {
+    this.tableName = "MetricDefinitions";
+    this.client = client;
+  }
+
+  public static async New(client: Client): Promise<MigrationMetricsRepository> {
+    const i = new MigrationMetricsRepository(client);
+    await i.mustExec();
+    return i;
+  }
+
+  protected async mustExec(): Promise<void> {
+    await this.client.query(tableSchema);
+  }
+
+  public async metricExists(metric: string): Promise<boolean> {
+    try {
+      const res = await this.getMetricDefinition(metric);
+      return res.metric === metric;
+    } catch {
+      // log error if wanted
+      return false;
+    }
+  }
+
+  /**
+   * This is a pretty unsafe way to do this since the tables may no exists, this may throw errors
+   */
+  public async computeMetric(
+    metric: string,
+    params: object
+  ): Promise<string | number> {
+    const metricDef = await this.getMetricDefinition(metric);
+
+    const p = metricDef.parameters;
+    if (p.filter((v) => Object.keys(params).includes(v)).length < p.length) {
+      const message = `[MetricsRepository][computeMetric] Error - Not all required parameters were passed. Expected ${p}, received ${params}`;
+      throw new Error(message);
+    }
+
+    const parameters = p.map((v) => params[v as keyof typeof params]);
+    const res = await this.client.query(metricDef.query, parameters);
+    if (res.rowCount < 1) {
+      const message = `[MetricsRepository][computeMetric] Error - No values returned when computing metric ${metric}`;
+      throw new Error(message);
+    }
+    const val = res.rows[0][metricDef.return_column];
+
+    if (val === null || val === undefined)
+      throw new Error(
+        `[MetricsRepository][computeMetric] Error - No values returned when computing metric ${metric}`
+      );
+    return val;
+  }
+
+  private async getMetricDefinition(metric: string): Promise<metricDefinition> {
+    const query = `SELECT * FROM "${this.tableName}" WHERE metric = $1`;
+    const res = await this.client.query(query, [metric]);
+    if (res.rowCount < 1) {
+      throw new Error(`No metric definition for metric ${metric}`);
+    }
+    return res.rows[0] as metricDefinition;
+  }
+}
+
+type metricDefinition = {
+  metric: string;
+  query: string; // make sure to typecast if necessary in the query
+  parameters: string[];
+  return_column: string;
+};

--- a/functions/src/infrastructure/postgres/MetricsRepository.ts
+++ b/functions/src/infrastructure/postgres/MetricsRepository.ts
@@ -10,6 +10,12 @@ CREATE TABLE IF NOT EXISTS "MetricDefinitions" (
 );
 `;
 
+const metricDefinitions: string = `
+INSERT INTO "MetricDefinitions" (metric, query, parameters, return_column) VALUES (
+  'runs', 'SELECT count(*) as runs FROM "Runs" WHERE action_id = $1 AND attempt_id IS NULL;', '{"actionId"}', 'runs'
+) ON CONFLICT DO NOTHING;
+`;
+
 export default class MigrationMetricsRepository implements IPostgresRepostiory {
   tableName: string;
   client: Client;
@@ -27,6 +33,7 @@ export default class MigrationMetricsRepository implements IPostgresRepostiory {
 
   protected async mustExec(): Promise<void> {
     await this.client.query(tableSchema);
+    await this.client.query(metricDefinitions);
   }
 
   public async metricExists(metric: string): Promise<boolean> {

--- a/functions/src/infrastructure/postgres/MigrationActionsRepository.ts
+++ b/functions/src/infrastructure/postgres/MigrationActionsRepository.ts
@@ -93,7 +93,8 @@ export default class MigrationActionRepository implements IPostgresRepostiory {
     if (res.rowCount < 1) {
       throw new Error(`No actions with id ${id} found.`);
     }
-    return res.rows[0];
+    const ret = res.rows[0];
+    return { ...ret, id: parseInt(ret.id) };
   }
 
   public async getByCreatorAndName(
@@ -107,6 +108,7 @@ export default class MigrationActionRepository implements IPostgresRepostiory {
     if (res.rowCount < 1) {
       throw new Error(`No actions with creator ${creator} and name ${name}.`);
     }
-    return res.rows[0];
+    const ret = res.rows[0];
+    return { ...ret, id: parseInt(ret.id) };
   }
 }

--- a/functions/src/infrastructure/postgres/MigrationActionsRepository.ts
+++ b/functions/src/infrastructure/postgres/MigrationActionsRepository.ts
@@ -95,4 +95,18 @@ export default class MigrationActionRepository implements IPostgresRepostiory {
     }
     return res.rows[0];
   }
+
+  public async getByCreatorAndName(
+    creator: string,
+    name: string
+  ): Promise<MigrationDbAction> {
+    const res = await this.client.query(
+      `SELECT * FROM "${this.tableName}" WHERE creator = $1 AND name = $2;`,
+      [creator, name]
+    );
+    if (res.rowCount < 1) {
+      throw new Error(`No actions with creator ${creator} and name ${name}.`);
+    }
+    return res.rows[0];
+  }
 }

--- a/functions/src/operations/MigrationGetBadgeOperation.ts
+++ b/functions/src/operations/MigrationGetBadgeOperation.ts
@@ -1,0 +1,43 @@
+import { Client } from "pg";
+import BadgeMetrics from "../domain/BadgeMetrics.type";
+import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
+import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
+
+type GetBadgeOperationParams = {
+  creator: string;
+  repo: string;
+  metric: BadgeMetrics;
+};
+
+type GetBadgeOperationReturn = {
+  url?: string;
+  outdated?: boolean;
+  raw?: string;
+  error?: Error;
+};
+
+export default async function GetBadgeOperation({
+  creator,
+  repo,
+  metric,
+}: GetBadgeOperationParams): Promise<GetBadgeOperationReturn> {
+  let PostgresClient: Client;
+  try {
+    // SupabaseClient = getClient();
+    const tmpClient = await PostgresConnectedClient();
+    if (tmpClient === null) {
+      throw new Error("Error initialize Postgres Client");
+    }
+    PostgresClient = tmpClient;
+  } catch (e) {
+    console.error(
+      `[GetBadgeOperation] Error - Unable to initialize SupabaseClient or PostgresClient`,
+      e
+    );
+    return { error: e as Error };
+  }
+
+  const BadgeRepository = await MigrationBadgesRepository.New(PostgresClient);
+  await BadgeRepository.isBadgeAccurate({ creator, name: repo, metric });
+  return {};
+}

--- a/functions/src/operations/MigrationGetBadgeOperation.ts
+++ b/functions/src/operations/MigrationGetBadgeOperation.ts
@@ -1,43 +1,170 @@
-import { Client } from "pg";
-import BadgeMetrics from "../domain/BadgeMetrics.type";
-import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
-import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
-
-type GetBadgeOperationParams = {
-  creator: string;
-  repo: string;
-  metric: BadgeMetrics;
-};
-
-type GetBadgeOperationReturn = {
-  url?: string;
-  outdated?: boolean;
-  raw?: string;
-  error?: Error;
-};
-
-export default async function GetBadgeOperation({
-  creator,
-  repo,
-  metric,
-}: GetBadgeOperationParams): Promise<GetBadgeOperationReturn> {
-  let PostgresClient: Client;
-  try {
-    // SupabaseClient = getClient();
-    const tmpClient = await PostgresConnectedClient();
-    if (tmpClient === null) {
-      throw new Error("Error initialize Postgres Client");
-    }
-    PostgresClient = tmpClient;
-  } catch (e) {
-    console.error(
-      `[GetBadgeOperation] Error - Unable to initialize SupabaseClient or PostgresClient`,
-      e
-    );
-    return { error: e as Error };
-  }
-
-  const BadgeRepository = await MigrationBadgesRepository.New(PostgresClient);
-  await BadgeRepository.isBadgeAccurate({ creator, name: repo, metric });
-  return {};
-}
+// import { makeBadge } from "badge-maker";
+// import { Client } from "pg";
+// import BadgeMetrics from "../domain/BadgeMetrics.type";
+// import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
+// import MigrationBadgeViewsRepository from "../infrastructure/postgres/BadgeViewsRepository";
+// import MigrationActionRunsRepository from "../infrastructure/postgres/MigrationActionRunsRepository";
+// import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
+//
+// type GetBadgeOperationParams = {
+//   creator: string;
+//   name: string;
+//   metric: BadgeMetrics;
+// };
+//
+// type GetBadgeOperationReturn =
+//   | { error: Error }
+//   | { badgeId: number; url: string; outdated: boolean }
+//   | {
+//       badgeId: string;
+//       raw: string;
+//       outdated?: boolean;
+//     };
+//
+// const opName = "GetBadgeOperation";
+//
+// export default async function GetBadgeOperation({
+//   creator,
+//   name,
+//   metric,
+// }: GetBadgeOperationParams): Promise<GetBadgeOperationReturn> {
+//   console.log(`[${opName}] START - New Request for`, { creator, name, metric });
+//   // start client
+//   const client = await PostgresConnectedClient();
+//   if (!client) {
+//     console.error("Unable to connect to persistance");
+//     console.log(`[${opName}] END - Error`);
+//     return { error: new Error("Unable to connect to persistance") };
+//   }
+//
+//   const badgeRepo = await MigrationBadgesRepository.New(client);
+//
+//   let badge;
+//   try {
+//     badge = await badgeRepo.getBadge({
+//       actionId: { creator, name },
+//       metric,
+//     });
+//   } catch (e) {
+//     console.warn(`[${opName}] Did not find badge`);
+//   }
+//
+//   try {
+//     if (!badge) {
+//       //const raw = await ({ actionId: 1, metric });// create badge
+//       const ret = {
+//         raw: "",
+//         outdated: true, // set outdated to create job for updating the badge
+//       };
+//       console.log(`[${opName}] END - Returned Raw Badge:`, ret);
+//
+//       return ret;
+//     } else {
+//       const accurate = await badgeRepo.isBadgeAccurate({
+//         creator,
+//         name,
+//         metric,
+//       });
+//       const ret = {
+//         url: badge.publicUri,
+//         outdated: !accurate, // if its not accurate, its outdated
+//       };
+//       console.log(`[${opName}] END - returning existing badge:`, ret);
+//       return ret;
+//     }
+//   } catch (e) {
+//     console.error(`[${opName}] Error - Error refreshing badge`, e);
+//     return { error: e as Error };
+//   }
+// }
+//
+// type metricBadgeDefinition = {
+//   name: BadgeMetrics;
+//   label: string;
+//   color: string | ((value: number | string) => string);
+//   query: string;
+//   params: string[];
+//   value: string;
+// };
+//
+// const metrics: metricBadgeDefinition[] = [
+//   {
+//     name: "runs",
+//     label: "Runs",
+//     color: "green",
+//     query: `SELECT count(*) as runs FROM "ActionRuns" WHERE action_id = $1;`,
+//     params: ["actionId"],
+//     value: "runs",
+//   },
+//   {
+//     name: "runs-per-month",
+//     label: "Runs Per Month",
+//     color: "green",
+//     query: `SELECT `,
+//     params: ["actionId"],
+//     value: "runs",
+//   },
+//   {
+//     name: "repos",
+//     label: "Repos",
+//     color: "green",
+//     query: `SELECT count(distinct(pulse_repo_id)) as repos FROM "Runs" WHERE action_id = $1;`,
+//     params: ["actionId"],
+//     value: "repos",
+//   },
+// ];
+//
+// export async function computeBadgeMetrics(
+//   metric: BadgeMetrics,
+//   client: Client,
+//   metricParams: object
+// ): Promise<string> {
+//   const metricDef = metrics.find((m) => m.name === metric);
+//   if (!metricDef) {
+//     console.error(
+//       `[computeBadgeMetrics] Error - No definition for metric ${metric}`
+//     );
+//     throw new Error(`No definition for metric ${metric}`);
+//   }
+//
+//   // validate passed parameters
+//   if (
+//     metricDef.params.filter((p) => Object.keys(metricParams).includes(p))
+//       .length != +metricDef.params.length
+//   )
+//     throw new Error(`Not all required parameters have been passed`);
+//
+//   const params = metricDef.params.map(
+//     (p) => metricParams[p as keyof typeof metricParams]
+//   );
+//   const res = await client.query(metricDef.query, params);
+//   if (res.rowCount < 1) {
+//     console.error(
+//       `[computeBadgeMetrics] Error - No row returned from metric query.`
+//     );
+//   }
+//   const value = res.rows[0]?.[metricDef.value] ?? 0; // default value of 0;
+//   const color =
+//     typeof metricDef.color === "string"
+//       ? metricDef.color
+//       : metricDef.color(value);
+//
+//   const badge = makeBadge({
+//     label: metricDef.label,
+//     color,
+//     message: value.toString(),
+//   });
+//   return badge;
+// }
+//
+// // export async function getRawBadge();
+//
+// export async function RefreshBadge({
+//   actionId,
+//   metric,
+// }: {
+//   actionId: number;
+//   metric: BadgeMetrics;
+// }): Promise<string> {
+//   return "";
+// }

--- a/functions/src/operations/MigrationGetBadgeOperation.ts
+++ b/functions/src/operations/MigrationGetBadgeOperation.ts
@@ -1,170 +1,101 @@
-// import { makeBadge } from "badge-maker";
-// import { Client } from "pg";
-// import BadgeMetrics from "../domain/BadgeMetrics.type";
-// import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
-// import MigrationBadgeViewsRepository from "../infrastructure/postgres/BadgeViewsRepository";
-// import MigrationActionRunsRepository from "../infrastructure/postgres/MigrationActionRunsRepository";
-// import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
-//
-// type GetBadgeOperationParams = {
-//   creator: string;
-//   name: string;
-//   metric: BadgeMetrics;
-// };
-//
-// type GetBadgeOperationReturn =
-//   | { error: Error }
-//   | { badgeId: number; url: string; outdated: boolean }
-//   | {
-//       badgeId: string;
-//       raw: string;
-//       outdated?: boolean;
-//     };
-//
-// const opName = "GetBadgeOperation";
-//
-// export default async function GetBadgeOperation({
-//   creator,
-//   name,
-//   metric,
-// }: GetBadgeOperationParams): Promise<GetBadgeOperationReturn> {
-//   console.log(`[${opName}] START - New Request for`, { creator, name, metric });
-//   // start client
-//   const client = await PostgresConnectedClient();
-//   if (!client) {
-//     console.error("Unable to connect to persistance");
-//     console.log(`[${opName}] END - Error`);
-//     return { error: new Error("Unable to connect to persistance") };
-//   }
-//
-//   const badgeRepo = await MigrationBadgesRepository.New(client);
-//
-//   let badge;
-//   try {
-//     badge = await badgeRepo.getBadge({
-//       actionId: { creator, name },
-//       metric,
-//     });
-//   } catch (e) {
-//     console.warn(`[${opName}] Did not find badge`);
-//   }
-//
-//   try {
-//     if (!badge) {
-//       //const raw = await ({ actionId: 1, metric });// create badge
-//       const ret = {
-//         raw: "",
-//         outdated: true, // set outdated to create job for updating the badge
-//       };
-//       console.log(`[${opName}] END - Returned Raw Badge:`, ret);
-//
-//       return ret;
-//     } else {
-//       const accurate = await badgeRepo.isBadgeAccurate({
-//         creator,
-//         name,
-//         metric,
-//       });
-//       const ret = {
-//         url: badge.publicUri,
-//         outdated: !accurate, // if its not accurate, its outdated
-//       };
-//       console.log(`[${opName}] END - returning existing badge:`, ret);
-//       return ret;
-//     }
-//   } catch (e) {
-//     console.error(`[${opName}] Error - Error refreshing badge`, e);
-//     return { error: e as Error };
-//   }
-// }
-//
-// type metricBadgeDefinition = {
-//   name: BadgeMetrics;
-//   label: string;
-//   color: string | ((value: number | string) => string);
-//   query: string;
-//   params: string[];
-//   value: string;
-// };
-//
-// const metrics: metricBadgeDefinition[] = [
-//   {
-//     name: "runs",
-//     label: "Runs",
-//     color: "green",
-//     query: `SELECT count(*) as runs FROM "ActionRuns" WHERE action_id = $1;`,
-//     params: ["actionId"],
-//     value: "runs",
-//   },
-//   {
-//     name: "runs-per-month",
-//     label: "Runs Per Month",
-//     color: "green",
-//     query: `SELECT `,
-//     params: ["actionId"],
-//     value: "runs",
-//   },
-//   {
-//     name: "repos",
-//     label: "Repos",
-//     color: "green",
-//     query: `SELECT count(distinct(pulse_repo_id)) as repos FROM "Runs" WHERE action_id = $1;`,
-//     params: ["actionId"],
-//     value: "repos",
-//   },
-// ];
-//
-// export async function computeBadgeMetrics(
-//   metric: BadgeMetrics,
-//   client: Client,
-//   metricParams: object
-// ): Promise<string> {
-//   const metricDef = metrics.find((m) => m.name === metric);
-//   if (!metricDef) {
-//     console.error(
-//       `[computeBadgeMetrics] Error - No definition for metric ${metric}`
-//     );
-//     throw new Error(`No definition for metric ${metric}`);
-//   }
-//
-//   // validate passed parameters
-//   if (
-//     metricDef.params.filter((p) => Object.keys(metricParams).includes(p))
-//       .length != +metricDef.params.length
-//   )
-//     throw new Error(`Not all required parameters have been passed`);
-//
-//   const params = metricDef.params.map(
-//     (p) => metricParams[p as keyof typeof metricParams]
-//   );
-//   const res = await client.query(metricDef.query, params);
-//   if (res.rowCount < 1) {
-//     console.error(
-//       `[computeBadgeMetrics] Error - No row returned from metric query.`
-//     );
-//   }
-//   const value = res.rows[0]?.[metricDef.value] ?? 0; // default value of 0;
-//   const color =
-//     typeof metricDef.color === "string"
-//       ? metricDef.color
-//       : metricDef.color(value);
-//
-//   const badge = makeBadge({
-//     label: metricDef.label,
-//     color,
-//     message: value.toString(),
-//   });
-//   return badge;
-// }
-//
-// // export async function getRawBadge();
-//
-// export async function RefreshBadge({
-//   actionId,
-//   metric,
-// }: {
-//   actionId: number;
-//   metric: BadgeMetrics;
-// }): Promise<string> {
-//   return "";
-// }
+import Badge from "../domain/Badge.type";
+import BadgeMetrics from "../domain/BadgeMetrics.type";
+import generateBadge from "../domain/methods/badges/generateBadge";
+import getBadgeLabel from "../domain/methods/badges/getBadgeLabel";
+import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
+import MigrationMetricsRepository from "../infrastructure/postgres/MetricsRepository";
+import MigrationActionRepository from "../infrastructure/postgres/MigrationActionsRepository";
+import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
+
+type GetBadgeOperationParams = {
+  creator: string;
+  name: string;
+  metric: BadgeMetrics;
+  params?: object;
+};
+
+type GetBadgeOperationReturn =
+  | { err: Error }
+  | { url: string; outdated: boolean; err?: Error }
+  | {
+      raw: string;
+      outdated?: boolean;
+      err?: Error;
+    };
+
+const opName = "GetBadgeOperation";
+
+export async function GetBadgeOperation({
+  creator,
+  name,
+  metric,
+  params = {},
+}: GetBadgeOperationParams): Promise<GetBadgeOperationReturn> {
+  console.log(`[${opName}] START - New Request for`, { creator, name, metric });
+  const client = await PostgresConnectedClient();
+  if (!client) {
+    console.error("Unable to connect to persistance");
+    console.log(`[${opName}] END - Error`);
+    return { err: new Error("Unable to connect to persistance") };
+  }
+
+  const badgeRepo = await MigrationBadgesRepository.New(client);
+
+  try {
+    let badge: Badge | undefined;
+    try {
+      badge = await badgeRepo.getBadge({
+        actionId: { creator, name },
+        metric,
+      });
+    } catch (e) {
+      console.warn(`[${opName}] Did not find badge.`, e);
+    }
+
+    if (badge) {
+      const isAccurate = await badgeRepo.isBadgeAccurate({
+        creator,
+        name,
+        metric,
+      });
+
+      const ret = { url: badge.publicUri, outdated: !isAccurate };
+      console.log(`[${opName}] END - Success: `, ret);
+      return ret;
+    } else {
+      const metricRepo = await MigrationMetricsRepository.New(client);
+
+      // check if metric exists
+      const metricExists = await metricRepo.metricExists(metric);
+      if (!metricExists) {
+        const ret = { err: new Error(`Metric ${metric} is not defined`) };
+        console.log(`[${opName}] END - Metric ${metric} is not defined.`);
+        return ret;
+      }
+
+      const actionRepo = await MigrationActionRepository.New(client);
+      const action = await actionRepo.getByCreatorAndName(creator, name);
+      const value = await metricRepo.computeMetric(metric, {
+        ...params,
+        actionId: action.id,
+        actionCreator: action.creator,
+        actionName: action.name,
+        actionLastUpdate: action.last_update,
+      });
+
+      const badge = generateBadge({
+        label: getBadgeLabel(metric),
+        value: value.toString(),
+      });
+      const rett = { raw: badge, outdated: true };
+      console.log(
+        `[${opName}] END - Created New Badge for metric ${metric}:`,
+        rett
+      );
+      return rett;
+    }
+  } catch (e) {
+    console.error(`[${opName}] Error - Unexpected Error`, e);
+    return { err: e as Error };
+  }
+}

--- a/functions/src/operations/MigrationRefreshBadgeOperation.ts
+++ b/functions/src/operations/MigrationRefreshBadgeOperation.ts
@@ -118,5 +118,9 @@ async function RefreshBadgeOperationImplementation(
     publicUri: uri,
   };
 
-  await badgeRepo.updateBadge(newBadgeDef);
+  if (badge == null) {
+    await badgeRepo.createBadge(newBadgeDef);
+  } else {
+    await badgeRepo.updateBadge(newBadgeDef);
+  }
 }

--- a/functions/src/operations/MigrationRefreshBadgeOperation.ts
+++ b/functions/src/operations/MigrationRefreshBadgeOperation.ts
@@ -1,0 +1,122 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Client } from "pg";
+import Badge from "../domain/Badge.type";
+import BadgeMetrics from "../domain/BadgeMetrics.type";
+import generateBadge from "../domain/methods/badges/generateBadge";
+import getBadgeLabel from "../domain/methods/badges/getBadgeLabel";
+import getBadgeStoragePath from "../domain/methods/badges/getBadgeStoragePath";
+import MigrationBadgesRepository from "../infrastructure/postgres/BadgesRepository";
+import MigrationMetricsRepository from "../infrastructure/postgres/MetricsRepository";
+import MigrationActionRepository from "../infrastructure/postgres/MigrationActionsRepository";
+import { PostgresConnectedClient } from "../infrastructure/postgres/PostgresClient";
+import BadgeStorage from "../infrastructure/supabase/storage/BadgeStorage";
+import { getClient } from "../infrastructure/supabase/SupabaseClient";
+
+const opName = "RefreshBadgeOperation";
+
+type RefreshBadgeOperationParams = {
+  creator: string;
+  name: string;
+  metric: string;
+  params?: object;
+};
+
+export async function RefreshBadgeOperation({
+  creator,
+  name,
+  metric,
+  params = {},
+}: RefreshBadgeOperationParams): Promise<void> {
+  console.log(
+    `[${opName}] START - New request for`,
+    JSON.stringify({ creator, name, metric })
+  );
+  const client = await PostgresConnectedClient();
+  if (!client) {
+    console.error("Unable to connect to persistance");
+    console.log(`[${opName}] END - Error`);
+    return;
+  }
+  try {
+    // start transaction
+    await client.query("BEGIN;");
+    const supaClient = getClient();
+    await RefreshBadgeOperationImplementation(
+      { creator, name, metric, params },
+      client,
+      supaClient
+    );
+    // commit transaction
+    await client.query("COMMIT;");
+    console.log(
+      `[${opName}] END - Success refreshing badge: ${JSON.stringify({
+        creator,
+        name,
+        metric,
+      })}`
+    );
+  } catch (e) {
+    // Rollback transaction on error
+    console.error(`[${opName}] END - Error encountered, rolling back.`, e);
+    await client.query("ROLLBACK;");
+  } finally {
+    // ensure we close the client cleanly after the RefreshBadgeOperationImplementation
+    await client.end();
+  }
+}
+
+async function RefreshBadgeOperationImplementation(
+  params: RefreshBadgeOperationParams,
+  pgClient: Client,
+  supabaseClient: SupabaseClient
+): Promise<void> {
+  const actionRepo = await MigrationActionRepository.New(pgClient);
+  const badgeRepo = await MigrationBadgesRepository.New(pgClient);
+  const { creator, name, metric } = params;
+  const action = await actionRepo.getByCreatorAndName(creator, name);
+  const badgeExists = await badgeRepo.badgeExists({
+    actionId: action.id,
+    metric: metric as BadgeMetrics,
+  });
+
+  let badge: Badge | null = null;
+  if (badgeExists) {
+    badge = await badgeRepo.getBadge({
+      actionId: action.id,
+      metric: metric as BadgeMetrics,
+    });
+  }
+
+  const metricRepo = await MigrationMetricsRepository.New(pgClient);
+
+  const value = await metricRepo.computeMetric(metric, {
+    ...params.params,
+    actionId: action.id,
+    actionCreator: action.creator,
+    actionName: action.name,
+    actionLastUpdate: action.last_update,
+  });
+  const path = badge
+    ? badge.locationPath
+    : getBadgeStoragePath({ creator, name, metric });
+  const badgeSvg = generateBadge({
+    label: getBadgeLabel(metric),
+    value: value.toString(),
+  });
+
+  const badgeStorageRepo = await BadgeStorage.New(supabaseClient);
+
+  await badgeStorageRepo.put(path, badgeSvg);
+  const uri = await badgeStorageRepo.getPublicUrl(path);
+
+  const newBadgeDef: Badge = {
+    actionId: action.id,
+    metric: metric as BadgeMetrics,
+    value: value.toString(),
+    lastGenerated: new Date(),
+    locationPath: path,
+    publicUri: uri,
+  };
+
+  await badgeRepo.updateBadge(newBadgeDef);
+}

--- a/functions/src/operations/MigrationRefreshBadgeOperation.ts
+++ b/functions/src/operations/MigrationRefreshBadgeOperation.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { Client } from "pg";
-import Badge from "../domain/Badge.type";
+import Badge, { BadgeData } from "../domain/Badge.type";
 import BadgeMetrics from "../domain/BadgeMetrics.type";
 import generateBadge from "../domain/methods/badges/generateBadge";
 import getBadgeLabel from "../domain/methods/badges/getBadgeLabel";
@@ -109,7 +109,7 @@ async function RefreshBadgeOperationImplementation(
   await badgeStorageRepo.put(path, badgeSvg);
   const uri = await badgeStorageRepo.getPublicUrl(path);
 
-  const newBadgeDef: Badge = {
+  const newBadgeDef: BadgeData = {
     actionId: action.id,
     metric: metric as BadgeMetrics,
     value: value.toString(),


### PR DESCRIPTION
## Work done
- Implemented the GetBadgeOperation & the RefreshBadgeOperation
- Implemented integration tests in github action workflow (starts local version of supabase)
- Updated the Github actions to include new environment variables.
c.f. #47 for documentation

## Commitlog
- updated Badges repository and tests
- fix Badge update
- fix again Badges repo
- properly fixed and implementedt the change in the Badge repository
- Added metrics repository
- initial implementation for the GetBadgeOperation
- implementation for the refresh badge operation
- updated test to not fail when unable to wipe relations & update workflow to cache supabase download(test)
- fixing tests
- updated action run and the tests
- trying to fix integration tests for refresh badge operation
- Attempting to identify where/why the tests are failing
- debugging
- fixed tests
- Fixed invalid tests
- Upadted implementation for creating a badge if it doesn't exist yet
- Added Badge request logging implementation & tests
- Upated GetBadgeOperationTests
- Added client creation fo Get Badges Tests
- added client redefinition on fail
- Updated github actions workflow with environment configuration

## Actions
Closes #47
